### PR TITLE
Support grid 4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: DeLuciatoR
 Type: Package
 Title: Make R Plots Match DeLucia Publication Specs
-Version: 0.1.2
+Version: 0.1.3
 Date: 2016-12-07
 Author: Chris Black
 Maintainer: Chris Black <chris@ckblack.org>


### PR DESCRIPTION
With grid < 4.0, we needed to do some unholy off-API mucking around inside unit data strucures to extract nulls from complex objects. with grid 4.0, our mucking around breaks but `grid::unitType` is available to do the same thing in a supported way.

Hopefully fixes #17, but I've only tested this on relatively simple plots so far -- @kevinwolz, please try this out and see what breaks it!